### PR TITLE
replacing object call for PHP 7.x compatability.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1663,7 +1663,7 @@ function pcast_update_grades($pcast=null, $userid=0, $nullifnone=true) {
         pcast_grade_item_update($pcast, $grades);
 
     } else if ($userid and $nullifnone) {
-        $grade = new object();
+        $grade = new stdClass();
         $grade->userid   = $userid;
         $grade->rawgrade = null;
         pcast_grade_item_update($pcast, $grade);


### PR DESCRIPTION
There is a call for new object() that is causing issues with user enrollment to a course where the mod is active. Updating to stdClass to correct the issue with PHP 7 reserved names. 